### PR TITLE
feat: allow setting all values for grouped lights in one api call

### DIFF
--- a/src/python_hue_v2/bridge.py
+++ b/src/python_hue_v2/bridge.py
@@ -150,9 +150,9 @@ class Bridge:
     def get_grouped_light(self, grouped_light_id: str) -> dict:
         return self._get_by_id(self._grouped_light_category, grouped_light_id)
 
-    def set_grouped_light_service(self, grouped_light_id: str, property_name: str, property_value: dict) -> dict:
+    def set_grouped_light_service(self, grouped_light_id: str, properties: dict) -> dict:
         return self._put_by_id(self._grouped_light_category, grouped_light_id,
-                               properties={property_name: property_value})
+                               properties=properties)
 
     def get_devices(self):
         return self._get(self._device_category)

--- a/src/python_hue_v2/grouped_light.py
+++ b/src/python_hue_v2/grouped_light.py
@@ -26,7 +26,7 @@ class GroupedLight:
     def _get(self):
         return self.bridge.get_grouped_light(self.grouped_light_id)
 
-    def _set(self, property_name: str, property_value: dict) -> dict:
+    def _set(self, properties: dict) -> dict:
         """_set is equal to HTTP PUT
 
         Arguments:
@@ -36,7 +36,7 @@ class GroupedLight:
         Returns:
             Response data, ResourceIdentifierPut, should be a dict for one id, not list
         """
-        return self.bridge.set_grouped_light_service(self.grouped_light_id, property_name, property_value)
+        return self.bridge.set_grouped_light_service(self.grouped_light_id, properties)
 
     @property
     def data_dict(self) -> dict:
@@ -48,7 +48,15 @@ class GroupedLight:
 
     @on.setter
     def on(self, value: bool):
-        self._set('on', {'on': value})
+        self._set({'on': {'on': value}})
+
+    def set_state(self, value: bool, brightness: float = None, duration_ms: int = None):
+        properties = {'on': {'on': value}}
+        if duration_ms:
+            properties['dynamics'] = {'duration': duration_ms}
+        if brightness:
+            properties['dimming'] = {'brightness': brightness}
+        self._set(properties)
 
     @property
     def type(self) -> str:
@@ -60,7 +68,7 @@ class GroupedLight:
 
     @brightness.setter
     def brightness(self, value: float):
-        self._set('dimming', {'brightness': value})
+        self._set({'dimming': {'brightness': value}})
 
     @property
     def owner(self) -> Owner:

--- a/tests/test_hue_integration.py
+++ b/tests/test_hue_integration.py
@@ -1,0 +1,59 @@
+import time
+from unittest import TestCase
+
+from python_hue_v2 import Hue, BridgeFinder
+
+finder = BridgeFinder()
+time.sleep(1)
+test_hostname = finder.get_bridge_server_lists()[0]
+test_key = '7K-IbBzEV3wZoXkTlSh6HyLTALLFsYrxCjIcW1o9'
+hue = Hue(test_hostname, test_key)
+
+
+class IntegrationTests(TestCase):
+    def test_set_on_grouped_light(self):
+        grouped_lights = hue.grouped_lights
+        grouped_light = grouped_lights[0]
+
+        test_cases = [
+            True,
+            False,
+        ]
+
+        for is_on in test_cases:
+            with self.subTest(is_on=is_on):
+                grouped_light.on = is_on
+                time.sleep(1)
+
+    def test_set_brightness_grouped_light(self):
+        grouped_lights = hue.grouped_lights
+        grouped_light = grouped_lights[0]
+        grouped_light.on = True
+
+        test_cases = [
+            30,
+            50,
+            100
+        ]
+
+        for brightness in test_cases:
+            with self.subTest(brightness=brightness):
+                grouped_light.brightness = brightness
+                time.sleep(1)
+
+    def test_set_state_grouped_light(self):
+        grouped_lights = hue.grouped_lights
+        grouped_light = grouped_lights[0]
+
+        test_cases = [
+            (True, 100, 6000),
+            (False, 50, 3000),
+            (True, 100, None),
+            (False, None, None),
+            (True, None, None),
+        ]
+
+        for is_on, brightness, duration in test_cases:
+            with self.subTest(is_on=is_on, brightness=brightness, duration=duration):
+                grouped_light.set_state(is_on, brightness, duration)
+                time.sleep(duration / 1000 if duration else 1)


### PR DESCRIPTION
Currently, the sdk allows you to set the on or brightness for a grouped light. This is fine for the most part, but it does not allow for setting `"dynamics": { "duration": 5000}`. This allows for the user to instruct the hue light how long the transition to take. In addition to this problem, you can not set property in a separate call like the current paradigm. In order for duration to be set correctly, it needs to be set in the same api call as the transition. Therefore, this pr also changes the inner calls to accept a dict instead of a singular property. 


Additionally, this will help with stability as right now if a user invokes the library like this:

```
grouped_light.on = True
grouped_light.brightness = 50
```

this will result in two api calls. It is quite unnecessary for this to be needed as the hue sdk allows you to set both attributes with one call. 
